### PR TITLE
adding link so font awesome works

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,6 @@
 {{ partial "header.html" . }}
 <body class="home-template">
+<link href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.3.0/css/font-awesome.css" rel="stylesheet"  type='text/css'>
 
     <!-- The big featured header on the homepage, with the site logo and description -->
     <header id="site-head" {{ if .Site.Params.cover }}style="background-image: url({{ .Site.Params.cover }})"{{ end }}>


### PR DESCRIPTION
font awesome icons don't work without a link. Not sure if this is the latest, but the down arrow icon now works for me with this added.
